### PR TITLE
Regarding autora issue #707 (https://github.com/AutoResearch/autora/i…

### DIFF
--- a/src/autora/experiment_runner/experimentation_manager/firebase/__init__.py
+++ b/src/autora/experiment_runner/experimentation_manager/firebase/__init__.py
@@ -368,7 +368,7 @@ def check_firebase_status(
                 is_aborted = False
                 if "pId" in value:
                     is_aborted = value['pId'] in pids_aborted
-                if is_aborted:
+                if is_aborted or (time_out is not None and time_from_started > time_out):
                     doc_ref_meta.update({key: {"start_time": None, "finished": False, "pId": None}})
                     available = True
                 else:


### PR DESCRIPTION
Regarding autora issue #707 (https://github.com/AutoResearch/autora/issues/707)


Old behaviour of check_firebase_status uses the argument 'timeout', but does not implement any functionality with it (confirm e.g. by simply ctrl+f time_out, its only listed in the documentation).

This behaviour is confusing for users, and causes failed experiments, when users actually timeout (blocking the experiment cycle, as one slot is permanently blocked and not continuing the experiment runner).

The proposed fix only changes one line (__init__.py, line 371). Confidence in the solution is low - I do not have much experience with firebase. However to my best understanding of the given code, and the experiments I have been running using this fix today, the proposed fix solves the issue at hand.